### PR TITLE
Twitter Card 向けにメタタグを追加する

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,12 @@
     <meta property="og:url" content="https://hex-crc.dskd.jp/">
     <meta property="og:image" content="https://hex-crc.dskd.jp/assets/images/ogp.png">
     <meta property="og:site_name" content="HEX Contrast Ratio Calcurator">
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@hexcrc" />
+    <meta property="og:url" content="https://hex-crc.dskd.jp" />
+    <meta property="og:title" content="HEX Contrast Ratio Calcurator" />
+    <meta property="og:description" content="HEXの2色（前景色と背景色）のカラーセットからコントラスト比を計算し、WCAG2.1が定める基準を達成しているかを判定します。" />
+    <meta property="og:image" content="https://hex-crc.dskd.jp/assets/images/ogp.png" />
     <link rel="image_src" href="https://hex-crc.dskd.jp/assets/images/ogp.png" type="image/png">
     <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png" type="image/png">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
Twitter アカウントの `@hexcrc` が空いていたのはびっくりだしラッキーだぜ。