### PR TITLE
カラーセットのWCAG達成判定が常にFailになってしまうバグを修正する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-crc",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-crc",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/ColorItemRatio.vue
+++ b/src/components/ColorItemRatio.vue
@@ -28,6 +28,7 @@ export default class ColorItemRatio extends Vue {
         ? Math.round(this.calculateContrastRatio(front, back) * 1000) / 1000
         : NaN
 
+    this.$emit('calc', _ratio)
     return _ratio
   }
 

--- a/src/components/ColorItemRow.vue
+++ b/src/components/ColorItemRow.vue
@@ -34,6 +34,7 @@
         :shows-label="showsLabel"
         :value="value"
         class="__cellInner"
+        @calc="handleCalcRatio"
       />
 
       <ColorItemLevel


### PR DESCRIPTION
fix #22 

`<ColorItemRaio />` コンポーネントから emit した値を `<ColorItemLevel />` コンポーネントに渡していたのを読めていませんでした。該当コミットをリバートしてbug fixとします。